### PR TITLE
Error handling for invalid watercourse link id

### DIFF
--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -21,6 +21,7 @@ function Map() {
   const [lat, setLat] = useState(53.48);
   const [zoom, setZoom] = useState(9);
   const [showSearch, setShowSearch] = useState(true);
+  const [searchError, setSearchError] = useState(null);
 
   const OSapiKey = process.env.REACT_APP_OS_API_KEY;
   const OSserviceUrl = "https://api.os.uk/maps/raster/v1/zxy";
@@ -95,15 +96,21 @@ function Map() {
 
     map.current.once("idle", () => {
       if (watercourseLinkId) {
-        showWatercourseLink(watercourseLinkId, map);
-        setShowSearch(false);
+        showWatercourseLink(watercourseLinkId, map)
+          .then(() => {
+            setShowSearch(false);
+          })
+          .catch((error) => {
+            setSearchError(error);
+            setShowSearch(true);
+          });
       }
     });
   }, [watercourseLinkId]);
 
   return (
     <>
-      <Search map={map} initialShow={showSearch} />
+      <Search map={map} initialShow={showSearch} initialError={searchError} />
       <SearchHereButton map={map} />
       <LayerToggles map={map} />
       <div ref={mapContainer} className="Map-container" />

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -13,11 +13,12 @@ import { OSGridToLatLng } from "../utils/coords";
 import "./Search.css";
 import { useNavigate } from "react-router-dom";
 import { unhighlightWatercourseLink } from "../utils/nearest-wc-link-to-site";
+import { showWatercourseLink } from "../utils/wc-link-from-id";
 
 function Search({ map, initialShow }) {
   const [results, setResults] = useState([]);
   const [query, setQuery] = useState("");
-
+  const [error, setError] = useState(null);
   const [show, setShow] = useState(true);
   const handleClose = () => {
     setShow(false);
@@ -43,8 +44,13 @@ function Search({ map, initialShow }) {
   const onSubmitWL = async (event) => {
     event.preventDefault();
     if (query) {
-      navigate("/watercourse-link/" + query);
-      setShow(false);
+      showWatercourseLink(query, map)
+        .then(() => {
+          setError(null);
+          setShow(false);
+          navigate("/watercourse-link/" + query);
+        })
+        .catch((error) => setError(error));
     }
   };
 
@@ -137,7 +143,11 @@ function Search({ map, initialShow }) {
                     type="text"
                     placeholder="Search for a Watercourse Link"
                     onChange={(e) => setQuery(e.target.value)}
+                    isInvalid={error}
                   />
+                  <Form.Control.Feedback type="invalid">
+                    No results found for given ID.
+                  </Form.Control.Feedback>
                 </Form.Group>
                 <Button
                   variant="primary"

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -15,11 +15,12 @@ import { useNavigate } from "react-router-dom";
 import { unhighlightWatercourseLink } from "../utils/nearest-wc-link-to-site";
 import { showWatercourseLink } from "../utils/wc-link-from-id";
 
-function Search({ map, initialShow }) {
+function Search({ map, initialShow, initialError }) {
   const [results, setResults] = useState([]);
   const [query, setQuery] = useState("");
   const [error, setError] = useState(null);
   const [show, setShow] = useState(true);
+  const [key, setKey] = useState("place");
   const handleClose = () => {
     setShow(false);
   };
@@ -40,6 +41,13 @@ function Search({ map, initialShow }) {
   useEffect(() => {
     setShow(initialShow);
   }, [initialShow]);
+
+  useEffect(() => {
+    if (initialError) {
+      setError(initialError);
+      setKey("watercourse-link");
+    }
+  }, [initialError]);
 
   const onSubmitWL = async (event) => {
     event.preventDefault();
@@ -110,7 +118,11 @@ function Search({ map, initialShow }) {
           <Offcanvas.Title>Water Network API</Offcanvas.Title>
         </Offcanvas.Header>
         <Offcanvas.Body>
-          <Tabs defaultActiveKey="place" className="Search-tabs">
+          <Tabs
+            activeKey={key}
+            onSelect={(k) => setKey(k)}
+            className="Search-tabs"
+          >
             <Tab eventKey="place" title="Place">
               <Form onSubmit={onSubmitPlace}>
                 <Form.Group controlId="search-query" className="mb-3">


### PR DESCRIPTION
If there's an error when using Search to find watercourse link:
- URL doesn't change
- shows Search bar with WL tab selected with ID and error

If there's an error when using URL directly:
- URL doesn't change
- shows Search bar with WL tab selected with error but no ID

IDs that are invalid to test out:
- 5000005143927697
- 5000005144824766