### PR TITLE
Manually link site to wclinks

### DIFF
--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -113,7 +113,7 @@ function Map() {
 
   return (
     <MapContext.Provider value={showNoWCLinkButton}>
-      <Search map={map} initialShow={showSearch} />
+      <Search map={map} initialShow={showSearch} initialError={searchError} />
       <SearchHereButton map={map} />
       <NoWatercourseLinkButton
         map={map}

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -25,7 +25,7 @@ function Map() {
   const [zoom, setZoom] = useState(9);
   const [showSearch, setShowSearch] = useState(false);
   const [searchError, setSearchError] = useState(null);
-  const [showNoWCLinkButton, setShowNoWCLinkButton] = useState(false);
+  const [showNoWCLinkButton, setShowNoWCLinkButton] = useState(null);
 
   const OSapiKey = process.env.REACT_APP_OS_API_KEY;
   const OSserviceUrl = "https://api.os.uk/maps/raster/v1/zxy";
@@ -115,7 +115,10 @@ function Map() {
     <MapContext.Provider value={showNoWCLinkButton}>
       <Search map={map} initialShow={showSearch} />
       <SearchHereButton map={map} />
-      <NoWatercourseLinkButton map={map} />
+      <NoWatercourseLinkButton
+        map={map}
+        setMapContext={setShowNoWCLinkButton}
+      />
       <LayerToggles map={map} />
       <div ref={mapContainer} className="Map-container" />
     </MapContext.Provider>

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -3,6 +3,7 @@ import mapboxgl from "!mapbox-gl"; // eslint-disable-line import/no-webpack-load
 
 import Search from "./Search";
 import SearchHereButton from "./SearchHereButton";
+import NoWatercourseLinkButton from "./NoWatercourseLinkButton";
 import LayerToggles from "./LayerToggles";
 
 import "./Map.css";
@@ -14,6 +15,8 @@ import { showWatercourseLink } from "../utils/wc-link-from-id";
 
 mapboxgl.accessToken = process.env.REACT_APP_MAPBOX_TOKEN;
 
+export const MapContext = React.createContext(null);
+
 function Map() {
   const mapContainer = useRef(null);
   const map = useRef(null);
@@ -22,6 +25,7 @@ function Map() {
   const [zoom, setZoom] = useState(9);
   const [showSearch, setShowSearch] = useState(false);
   const [searchError, setSearchError] = useState(null);
+  const [showNoWCLinkButton, setShowNoWCLinkButton] = useState(false);
 
   const OSapiKey = process.env.REACT_APP_OS_API_KEY;
   const OSserviceUrl = "https://api.os.uk/maps/raster/v1/zxy";
@@ -78,7 +82,7 @@ function Map() {
       );
 
       setupEmptyOverlays(map.current);
-      setupLayerPopups(map.current);
+      setupLayerPopups(map.current, setShowNoWCLinkButton);
     });
   });
 
@@ -108,12 +112,13 @@ function Map() {
   });
 
   return (
-    <>
-      <Search map={map} initialShow={showSearch} initialError={searchError} />
+    <MapContext.Provider value={showNoWCLinkButton}>
+      <Search map={map} initialShow={showSearch} />
       <SearchHereButton map={map} />
+      <NoWatercourseLinkButton map={map} />
       <LayerToggles map={map} />
       <div ref={mapContainer} className="Map-container" />
-    </>
+    </MapContext.Provider>
   );
 }
 

--- a/src/components/NoWatercourseLinkButton.css
+++ b/src/components/NoWatercourseLinkButton.css
@@ -1,0 +1,6 @@
+.NoWatercourseLinkButton {
+  position: absolute;
+  z-index: 1;
+  bottom: 18rem;
+  left: 1rem;
+}

--- a/src/components/NoWatercourseLinkButton.js
+++ b/src/components/NoWatercourseLinkButton.js
@@ -6,7 +6,7 @@ import { saveWatercourseLinkSiteAssociation } from "../utils/water-network-data"
 import { setWCLinkSelectMode, setWCLinkHoverMode } from "../utils/popups";
 import { unhighlightWatercourseLink } from "../utils/map";
 
-export const NO_WC_LINK = "NO_WC_LINK_OVERRIDE";
+const NO_WC_LINK = "NO_WC_LINK_OVERRIDE";
 
 function NoWatercourseLinkButton({ map, setMapContext }) {
   const selectModeCurrentSite = useContext(MapContext);
@@ -26,7 +26,7 @@ function NoWatercourseLinkButton({ map, setMapContext }) {
   return (
     selectModeCurrentSite && (
       <Button
-        className="NoWatercourseLinkButton"
+        className="NoWatercourseLinkButton govuk-button"
         variant="warning"
         onClick={selectNoWatercourseLink}
       >

--- a/src/components/NoWatercourseLinkButton.js
+++ b/src/components/NoWatercourseLinkButton.js
@@ -1,14 +1,35 @@
 import React, { useContext } from "react";
 import Button from "react-bootstrap/Button";
 import "./NoWatercourseLinkButton.css";
-import { MapContext } from "./Map.js";
+import { MapContext } from "./Map";
+import { saveWatercourseLinkSiteAssociation } from "../utils/water-network-data";
+import { setWCLinkSelectMode, setWCLinkHoverMode } from "../utils/popups";
+import { unhighlightWatercourseLink } from "../utils/map";
 
-function NoWatercourseLinkButton({ map }) {
-  const mapState = useContext(MapContext);
+export const NO_WC_LINK = "NO_WC_LINK_OVERRIDE";
+
+function NoWatercourseLinkButton({ map, setMapContext }) {
+  const selectModeCurrentSite = useContext(MapContext);
+
+  const selectNoWatercourseLink = async () => {
+    await saveWatercourseLinkSiteAssociation(
+      NO_WC_LINK,
+      selectModeCurrentSite
+    ).finally(() => {
+      unhighlightWatercourseLink(map.current);
+
+      setWCLinkSelectMode(false, setMapContext);
+      setWCLinkHoverMode(map.current, null, false);
+    });
+  };
 
   return (
-    mapState && (
-      <Button className="NoWatercourseLinkButton" variant="warning">
+    selectModeCurrentSite && (
+      <Button
+        className="NoWatercourseLinkButton"
+        variant="warning"
+        onClick={selectNoWatercourseLink}
+      >
         No Watercourse Link
       </Button>
     )

--- a/src/components/NoWatercourseLinkButton.js
+++ b/src/components/NoWatercourseLinkButton.js
@@ -1,0 +1,18 @@
+import React, { useContext } from "react";
+import Button from "react-bootstrap/Button";
+import "./NoWatercourseLinkButton.css";
+import { MapContext } from "./Map.js";
+
+function NoWatercourseLinkButton({ map }) {
+  const mapState = useContext(MapContext);
+
+  return (
+    mapState && (
+      <Button className="NoWatercourseLinkButton" variant="warning">
+        No Watercourse Link
+      </Button>
+    )
+  );
+}
+
+export default NoWatercourseLinkButton;

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -12,7 +12,7 @@ import { OSGridToLatLng } from "../utils/coords";
 
 import "./Search.css";
 import { useNavigate } from "react-router-dom";
-import { unhighlightWatercourseLink } from "../utils/nearest-wc-link-to-site";
+import { unhighlightWatercourseLink } from "../utils/map";
 import { showWatercourseLink } from "../utils/wc-link-from-id";
 
 function Search({ map, initialShow, initialError }) {

--- a/src/components/SearchHereButton.js
+++ b/src/components/SearchHereButton.js
@@ -9,7 +9,7 @@ import { debounce } from "../utils/misc";
 
 import "./SearchHereButton.css";
 import { useNavigate } from "react-router-dom";
-import { unhighlightWatercourseLink } from "../utils/nearest-wc-link-to-site";
+import { unhighlightWatercourseLink } from "../utils/map";
 
 function SearchHereButton({ map }) {
   const navigate = useNavigate();

--- a/src/utils/map.js
+++ b/src/utils/map.js
@@ -152,3 +152,10 @@ export const bboxPolygon = ([swLng, swLat, neLng, neLat]) => {
     },
   };
 };
+
+export const unhighlightWatercourseLink = (map) => {
+  map.getSource("highlightWatercourseLink").setData({
+    type: "FeatureCollection",
+    features: [],
+  });
+};

--- a/src/utils/map.js
+++ b/src/utils/map.js
@@ -10,6 +10,7 @@ const addGeoJSONSource = (map, name) => {
       type: "FeatureCollection",
       features: [],
     },
+    generateId: true,
   });
 };
 
@@ -39,8 +40,18 @@ export const setupEmptyOverlays = (map) => {
       "line-cap": "round",
     },
     paint: {
-      "line-color": "#0079c4",
-      "line-width": 4,
+      "line-color": [
+        "case",
+        ["boolean", ["feature-state", "hover"], false],
+        "orange",
+        "#0079c4",
+      ],
+      "line-width": [
+        "case",
+        ["boolean", ["feature-state", "hover"], false],
+        8,
+        4,
+      ],
     },
   });
 

--- a/src/utils/nearest-wc-link-to-site.js
+++ b/src/utils/nearest-wc-link-to-site.js
@@ -1,4 +1,9 @@
-import { waterNetworkAPIBase, getURL } from "../utils/water-network-data";
+import {
+  waterNetworkAPIBase,
+  waterNetworkBaseURL,
+  getURL,
+  headers,
+} from "../utils/water-network-data";
 
 const getNearestWCLinkToPoint = async (coords) => {
   const url =
@@ -10,10 +15,35 @@ const getNearestWCLinkToPoint = async (coords) => {
   return await getURL(url);
 };
 
-export const highlightNearestWatercourseLink = async (coords, map) => {
-  await getNearestWCLinkToPoint(coords).then((watercourseLink) => {
-    map.getSource("highlightWatercourseLink").setData(watercourseLink);
+const getUserAssociatedWCLink = async (siteURI) => {
+  const url =
+    waterNetworkBaseURL +
+    "/retrieve-user-associated-watercourse-link" +
+    `?site_uri=${encodeURIComponent(siteURI)}`;
+
+  return await fetch(url, { method: "GET", headers: headers }).then((r) => {
+    if (r.status === 404) {
+      return;
+    } else {
+      return r.json();
+    }
   });
+};
+
+export const highlightNearestWatercourseLink = async (site, map) => {
+  const siteURI = site.properties.uri;
+  const userAssociatedWCLink = await getUserAssociatedWCLink(siteURI);
+
+  let wcLink = null;
+
+  if (userAssociatedWCLink) {
+    wcLink = userAssociatedWCLink;
+  } else {
+    const coords = site.geometry.coordinates;
+    wcLink = await getNearestWCLinkToPoint(coords);
+  }
+
+  map.getSource("highlightWatercourseLink").setData(wcLink);
 };
 
 export const unhighlightWatercourseLink = (map) => {

--- a/src/utils/nearest-wc-link-to-site.js
+++ b/src/utils/nearest-wc-link-to-site.js
@@ -4,6 +4,7 @@ import {
   getURL,
   headers,
 } from "../utils/water-network-data";
+import { unhighlightWatercourseLink } from "../utils/map";
 
 const getNearestWCLinkToPoint = async (coords) => {
   const url =
@@ -36,7 +37,10 @@ export const highlightNearestWatercourseLink = async (site, map) => {
 
   let wcLink = null;
 
-  if (userAssociatedWCLink) {
+  if (userAssociatedWCLink?.status === "No watercourse link") {
+    unhighlightWatercourseLink(map);
+    return;
+  } else if (userAssociatedWCLink) {
     wcLink = userAssociatedWCLink;
   } else {
     const coords = site.geometry.coordinates;
@@ -44,11 +48,4 @@ export const highlightNearestWatercourseLink = async (site, map) => {
   }
 
   map.getSource("highlightWatercourseLink").setData(wcLink);
-};
-
-export const unhighlightWatercourseLink = (map) => {
-  map.getSource("highlightWatercourseLink").setData({
-    type: "FeatureCollection",
-    features: [],
-  });
 };

--- a/src/utils/popups.js
+++ b/src/utils/popups.js
@@ -34,7 +34,7 @@ const closePopup = () => {
 };
 
 window.WCLinkSelectMode = null;
-const setWCLinkSelectMode = (val, setMapContext) => {
+export const setWCLinkSelectMode = (val, setMapContext) => {
   setMapContext(val);
   window.WCLinkSelectMode = val;
 };
@@ -136,7 +136,7 @@ const newPopup = (coords, text, map, setMapContext) => {
   });
 };
 
-const setWCLinkHoverMode = (map, wcLinkID, val) => {
+export const setWCLinkHoverMode = (map, wcLinkID, val) => {
   if (wcLinkID) {
     if (val) {
       map.setFeatureState(

--- a/src/utils/popups.js
+++ b/src/utils/popups.js
@@ -213,15 +213,16 @@ export const setupLayerPopups = (map, setMapContext) => {
     if (e.originalEvent.defaultPrevented) return;
     e.originalEvent.preventDefault();
     const coords = getCoords(e);
-    const feature = e.features[0];
+    const site = e.features[0];
 
-    const siteEndpoint = ensureHttps(feature.properties.uri);
+    const siteEndpoint = ensureHttps(site.properties.uri);
     const flow = await getLatestFlowReadingInfo(siteEndpoint);
-    feature.properties.flow = flow;
 
-    const text = sitePropertiesToHTML(feature);
-    newPopup(coords, text, map);
-    await highlightNearestWatercourseLink(coords, map);
+    site.properties.flow = flow;
+    const text = sitePropertiesToHTML(site);
+
+    newPopup(coords, text, map, setMapContext);
+    await highlightNearestWatercourseLink(site, map);
   });
 
   for (const layer of [
@@ -238,8 +239,8 @@ export const setupLayerPopups = (map, setMapContext) => {
       e.originalEvent.preventDefault();
 
       const coords = getCoords(e);
-      const text = sitePropertiesToHTML(e.features[0]);
       const site = e.features[0];
+      const text = sitePropertiesToHTML(site);
 
       newPopup(coords, text, map, setMapContext);
       await highlightNearestWatercourseLink(site, map);

--- a/src/utils/popups.js
+++ b/src/utils/popups.js
@@ -18,18 +18,40 @@ const toTableCells = (displayProps) => {
     .join("");
 };
 
-const popupTableHTML = (title, displayProps, url) => {
-  let link = "";
-
-  if (url) {
-    link = `<tr><a target="_blank" href=${url}>Site API endpoint</a></tr>`;
-  }
-
+const basicPopupTableHTML = (title, displayProps) => {
   return `<table>
        <caption style="font-weight: bold; caption-side: top">${title}</caption>
         ${toTableCells(displayProps)}
-     </table>
-     ${link}`;
+     </table>`;
+};
+
+const closePopup = () => {
+  const popups = document.getElementsByClassName("mapboxgl-popup");
+  for (const popup of popups) {
+    popup.remove();
+  }
+};
+
+window.WCLinkSelectMode = false;
+const setWCLinkSelectMode = (val) => {
+  window.WCLinkSelectMode = val;
+};
+
+const associateWatercourseLink = () => {
+  closePopup();
+  setWCLinkSelectMode(true);
+  // next watercourselink click gets associated
+};
+
+const sitePopupHTML = (title, displayProps, url) => {
+  const rawAPILink = `<a target="_blank" href=${url}>Site API endpoint</a>`;
+  const associateWCLink = `<button class="btn btn-outline-secondary btn-sm mt-2"
+                                   id="associate-wc-link-button"
+                           >Associate watercourse link</button>`;
+
+  return `${basicPopupTableHTML(title, displayProps)}
+          ${rawAPILink}
+          ${associateWCLink}`;
 };
 
 const hydroNodePropertiesToHTML = ({ properties }) => {
@@ -38,7 +60,7 @@ const hydroNodePropertiesToHTML = ({ properties }) => {
     Category: getLastURLSegment(properties.hydroNodeCategory),
   };
 
-  return popupTableHTML("Hydro Node", displayProps);
+  return basicPopupTableHTML("Hydro Node", displayProps);
 };
 
 const watercourseLinkPropertiesToHTML = ({ properties }) => {
@@ -64,7 +86,7 @@ const watercourseLinkPropertiesToHTML = ({ properties }) => {
     displayProps["Catchment ID"] = properties.catchmentId;
   }
 
-  return popupTableHTML("Watercourse Link", displayProps);
+  return basicPopupTableHTML("Watercourse Link", displayProps);
 };
 
 const sitePropertiesToHTML = ({ properties, source }) => {
@@ -81,6 +103,11 @@ const sitePropertiesToHTML = ({ properties, source }) => {
     url = properties.uri;
   }
 
+  return sitePopupHTML(
+    "Monitoring Site",
+    { Name: properties.label, URI: properties.uri },
+    url
+  );
   const displayProps = { Name: properties.label, URI: properties.uri };
 
   if (properties.flow) {
@@ -95,7 +122,10 @@ const getCoords = (event) => {
 };
 
 const newPopup = (coords, text, map) => {
-  return new mapboxgl.Popup().setLngLat(coords).setHTML(text).addTo(map);
+  new mapboxgl.Popup().setLngLat(coords).setHTML(text).addTo(map);
+
+  const button = document.getElementById("associate-wc-link-button");
+  button?.addEventListener("click", associateWatercourseLink);
 };
 
 const getLatestCompleteReading = (readings) => {

--- a/src/utils/popups.js
+++ b/src/utils/popups.js
@@ -239,9 +239,10 @@ export const setupLayerPopups = (map) => {
 
       const coords = getCoords(e);
       const text = sitePropertiesToHTML(e.features[0]);
+      const site = e.features[0];
 
       newPopup(coords, text, map);
-      await highlightNearestWatercourseLink(coords, map);
+      await highlightNearestWatercourseLink(site, map);
     });
   }
 

--- a/src/utils/popups.js
+++ b/src/utils/popups.js
@@ -47,8 +47,9 @@ const enableAssociateWatercourseLinkMode = (siteURI, setMapContext) => {
 
 const sitePopupHTML = (title, displayProps, url) => {
   const rawAPILink = `<a target="_blank" href=${url}>Site API endpoint</a>`;
-  const associateWCLink = `<button class="btn btn-outline-secondary btn-sm mt-2"
+  const associateWCLink = `<button class="govuk-button btn-sm mt-3"
                                    id="associate-wc-link-button"
+                                   style="font-size:0.9rem"
                                    data-site-uri="${displayProps.URI}"
                            >Associate watercourse link</button>`;
 
@@ -106,18 +107,13 @@ const sitePropertiesToHTML = ({ properties, source }) => {
     url = properties.uri;
   }
 
-  return sitePopupHTML(
-    "Monitoring Site",
-    { Name: properties.label, URI: properties.uri },
-    url
-  );
   const displayProps = { Name: properties.label, URI: properties.uri };
 
   if (properties.flow) {
     displayProps["Latest complete flow reading"] = properties.flow;
   }
 
-  return popupTableHTML("Monitoring Site", displayProps, url);
+  return sitePopupHTML("Monitoring Site", displayProps, url);
 };
 
 const getCoords = (event) => {

--- a/src/utils/water-network-data.js
+++ b/src/utils/water-network-data.js
@@ -1,6 +1,6 @@
 import { getMapBoundingBox, bboxPolygon } from "../utils/map";
 
-const waterNetworkBaseURL =
+export const waterNetworkBaseURL =
   // "https://defra-water-network-prod.publishmydata.com/water-network"
   "http://localhost:3001/water-network";
 export const waterNetworkAPIBase = waterNetworkBaseURL + "/api/v1";
@@ -9,7 +9,7 @@ export const waterNetworkAPIKey =
 // "0c9f52c42e9a0fda5cb20e6489a7e62c42bcfcb5";
 // process.env.REACT_APP_WATER_NETWORK_API_KEY;
 
-const headers = {
+export const headers = {
   Authorization: `Basic ${waterNetworkAPIKey}`,
 };
 
@@ -105,12 +105,12 @@ export const getHydroNode = async (id) => {
 
 export const saveWatercourseLinkSiteAssociation = async (
   watercourseLinkId,
-  site
+  siteURI
 ) => {
   const url = waterNetworkBaseURL + "/associate-watercourse-link";
 
   return await postURL(url, {
     watercourse_link_id: watercourseLinkId,
-    site_url: site,
+    site_uri: siteURI,
   });
 };

--- a/src/utils/water-network-data.js
+++ b/src/utils/water-network-data.js
@@ -1,17 +1,34 @@
 import { getMapBoundingBox, bboxPolygon } from "../utils/map";
 
-export const waterNetworkAPIBase =
-  "https://defra-water-network-prod.publishmydata.com/water-network/api/v1";
-export const waterNetworkAPIKey = process.env.REACT_APP_WATER_NETWORK_API_KEY;
+const waterNetworkBaseURL =
+  // "https://defra-water-network-prod.publishmydata.com/water-network"
+  "http://localhost:3001/water-network";
+export const waterNetworkAPIBase = waterNetworkBaseURL + "/api/v1";
+export const waterNetworkAPIKey =
+  "dGVzdEBleGFtcGxlLmNvbTowYzlmNTJjNDJlOWEwZmRhNWNiMjBlNjQ4OWE3ZTYyYzQyYmNmY2I1";
+// "0c9f52c42e9a0fda5cb20e6489a7e62c42bcfcb5";
+// process.env.REACT_APP_WATER_NETWORK_API_KEY;
+
+const headers = {
+  Authorization: `Basic ${waterNetworkAPIKey}`,
+};
 
 export const getURL = async (url) => {
-  const headers = {
-    Authorization: `Basic ${waterNetworkAPIKey}`,
-  };
-
   return await fetch(url, { method: "GET", headers: headers }).then(
     (response) => response.json()
   );
+};
+
+const postURL = async (url, body) => {
+  return await fetch(url, {
+    method: "POST",
+    headers: {
+      ...headers,
+      Accept: "application.json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  }).then((response) => response.json());
 };
 
 const getNextPageLink = (response) => {
@@ -84,4 +101,16 @@ export const getWatercourseLink = async (id) => {
 export const getHydroNode = async (id) => {
   const url = `${waterNetworkAPIBase}/collections/HydroNode/items/${id}`;
   return await getURL(url);
+};
+
+export const saveWatercourseLinkSiteAssociation = async (
+  watercourseLinkId,
+  site
+) => {
+  const url = waterNetworkBaseURL + "/associate-watercourse-link";
+
+  return await postURL(url, {
+    watercourse_link_id: watercourseLinkId,
+    site_url: site,
+  });
 };

--- a/src/utils/water-network-data.js
+++ b/src/utils/water-network-data.js
@@ -1,13 +1,9 @@
 import { getMapBoundingBox, bboxPolygon } from "../utils/map";
 
 export const waterNetworkBaseURL =
-  // "https://defra-water-network-prod.publishmydata.com/water-network"
-  "http://localhost:3001/water-network";
+  "https://defra-water-network-prod.publishmydata.com/water-network";
 export const waterNetworkAPIBase = waterNetworkBaseURL + "/api/v1";
-export const waterNetworkAPIKey =
-  "dGVzdEBleGFtcGxlLmNvbTowYzlmNTJjNDJlOWEwZmRhNWNiMjBlNjQ4OWE3ZTYyYzQyYmNmY2I1";
-// "0c9f52c42e9a0fda5cb20e6489a7e62c42bcfcb5";
-// process.env.REACT_APP_WATER_NETWORK_API_KEY;
+export const waterNetworkAPIKey = process.env.REACT_APP_WATER_NETWORK_API_KEY;
 
 export const headers = {
   Authorization: `Basic ${waterNetworkAPIKey}`,


### PR DESCRIPTION
This PR adds the ability to manually select which watercourse link a site is associated with (if any). There's a new button in the popup for only sites, which when clicked puts the map into a new "select mode", where links are highlighted in orange and a new button appears to select "no watercourse link". Changes are saved to the water network api stardog db (changes to enable that are here: https://github.com/Swirrl/defra-water-network-api/pull/125)

<img width="300" alt="image" src="https://user-images.githubusercontent.com/11531673/194933677-ce8a6198-888b-4003-99e7-979fa879d647.png">

<img width="591" alt="image" src="https://user-images.githubusercontent.com/11531673/194933701-3aab4c3f-4660-4f3b-b9ef-4a264df970e3.png">

