### PR TITLE
Improve upstream/downstream

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -12,7 +12,10 @@ import { OSGridToLatLng } from "../utils/coords";
 
 import "./Search.css";
 import { useNavigate } from "react-router-dom";
-import { unhighlightWatercourseLink } from "../utils/map";
+import {
+  clearUpstreamDownstream,
+  unhighlightWatercourseLink,
+} from "../utils/map";
 import { showWatercourseLink } from "../utils/wc-link-from-id";
 
 function Search({ map, initialShow, initialError }) {
@@ -71,6 +74,7 @@ function Search({ map, initialShow, initialError }) {
     setResults([]);
     navigate("/");
     unhighlightWatercourseLink(map.current);
+    clearUpstreamDownstream(map.current);
     await displayWaterNetworkFeaturesInMapViewport(map.current);
     await displayMonitoringSitesFeaturesInMapViewport(map.current);
   };

--- a/src/components/SearchHereButton.css
+++ b/src/components/SearchHereButton.css
@@ -42,6 +42,7 @@
 
 .SearchHereButton-tooltip-overlay,
 .SearchHereButton {
+  margin-bottom: 0;
   position: absolute;
   z-index: 1;
   top: 4rem;

--- a/src/components/SearchHereButton.js
+++ b/src/components/SearchHereButton.js
@@ -9,7 +9,10 @@ import { debounce } from "../utils/misc";
 
 import "./SearchHereButton.css";
 import { useNavigate } from "react-router-dom";
-import { unhighlightWatercourseLink } from "../utils/map";
+import {
+  clearUpstreamDownstream,
+  unhighlightWatercourseLink,
+} from "../utils/map";
 
 function SearchHereButton({ map }) {
   const navigate = useNavigate();
@@ -17,6 +20,7 @@ function SearchHereButton({ map }) {
   const renderMapItems = async () => {
     navigate("/");
     unhighlightWatercourseLink(map.current);
+    clearUpstreamDownstream(map.current);
     await displayWaterNetworkFeaturesInMapViewport(map.current);
     await displayMonitoringSitesFeaturesInMapViewport(map.current);
   };

--- a/src/utils/icons/chevronBlue.svg
+++ b/src/utils/icons/chevronBlue.svg
@@ -1,0 +1,3 @@
+<svg width="452" height="383" viewBox="0 0 452 383" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 151L226 0.5L452 151V383L226 232.5L0 383V151Z" fill="#598b9c"/>
+</svg>

--- a/src/utils/icons/chevronPink.svg
+++ b/src/utils/icons/chevronPink.svg
@@ -1,0 +1,3 @@
+<svg width="452" height="383" viewBox="0 0 452 383" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 151L226 0.5L452 151V383L226 232.5L0 383V151Z" fill="#BD7C8A"/>
+</svg>

--- a/src/utils/map.js
+++ b/src/utils/map.js
@@ -224,3 +224,16 @@ export const unhighlightWatercourseLink = (map) => {
     features: [],
   });
 };
+
+export const clearUpstreamDownstream = (map) => {
+  map.getSource("upstreamWatercourseLinks").setData({
+    type: "FeatureCollection",
+    features: [],
+  });
+
+  map.getSource("downstreamWatercourseLinks").setData({
+    type: "FeatureCollection",
+    features: [],
+  });
+};
+

--- a/src/utils/map.js
+++ b/src/utils/map.js
@@ -1,3 +1,6 @@
+import chevronPink from "./icons/chevronPink.svg";
+import chevronBlue from "./icons/chevronBlue.svg";
+
 export const getMapBoundingBox = (map) => {
   const { _sw, _ne } = map.getBounds();
   return [_sw.lng, _sw.lat, _ne.lng, _ne.lat];
@@ -67,6 +70,68 @@ export const setupEmptyOverlays = (map) => {
     paint: {
       "line-color": "red",
       "line-width": 8,
+    },
+  });
+
+  addGeoJSONSource(map, "upstreamWatercourseLinks");
+  map.addLayer({
+    id: "upstreamWatercourseLinks",
+    type: "line",
+    source: "upstreamWatercourseLinks",
+    layout: {
+      "line-join": "round",
+      "line-cap": "round",
+    },
+    paint: {
+      "line-color": "pink",
+      "line-width": 8,
+    },
+  });
+
+  const upstreamIcon = new Image(8, 8);
+  upstreamIcon.src = chevronPink;
+  upstreamIcon.onload = () => map.addImage("upstreamIcon", upstreamIcon);
+  map.addLayer({
+    id: "upstreamWatercourseLinksArrows",
+    type: "symbol",
+    source: "upstreamWatercourseLinks",
+    paint: {},
+    layout: {
+      "symbol-placement": "line",
+      "symbol-spacing": 20,
+      "icon-image": "upstreamIcon",
+      "icon-rotate": 90,
+    },
+  });
+
+  addGeoJSONSource(map, "downstreamWatercourseLinks");
+  map.addLayer({
+    id: "downstreamWatercourseLinks",
+    type: "line",
+    source: "downstreamWatercourseLinks",
+    layout: {
+      "line-join": "round",
+      "line-cap": "round",
+    },
+    paint: {
+      "line-color": "light blue",
+      "line-width": 8,
+    },
+  });
+
+  const downstreamIcon = new Image(8, 8);
+  downstreamIcon.src = chevronBlue;
+  downstreamIcon.onload = () => map.addImage("downstreamIcon", downstreamIcon);
+  map.addLayer({
+    id: "downstreamWatercourseLinksArrows",
+    type: "symbol",
+    source: "downstreamWatercourseLinks",
+    paint: {},
+    layout: {
+      "symbol-placement": "line",
+      "symbol-spacing": 20,
+      "icon-image": "downstreamIcon",
+      "icon-rotate": 90,
     },
   });
 

--- a/src/utils/nearest-wc-link-to-site.js
+++ b/src/utils/nearest-wc-link-to-site.js
@@ -22,13 +22,13 @@ const getUserAssociatedWCLink = async (siteURI) => {
     "/retrieve-user-associated-watercourse-link" +
     `?site_uri=${encodeURIComponent(siteURI)}`;
 
-  return await fetch(url, { method: "GET", headers: headers }).then((r) => {
-    if (r.status === 404) {
-      return;
-    } else {
-      return r.json();
-    }
-  });
+  const result = await fetch(url, { method: "GET", headers: headers });
+
+  if (result.status === 404) {
+    return;
+  } else {
+    return await result.json();
+  }
 };
 
 export const highlightNearestWatercourseLink = async (site, map) => {

--- a/src/utils/popups.js
+++ b/src/utils/popups.js
@@ -83,27 +83,27 @@ const getUpstream = async (id) => {
 };
 // TODO: catch 404s
 const highlightUpstreamWatercourseLinks = async (id, map) => {
-  await getUpstream(id).then(async (upstreamWatercourseLinks) => {
-    closePopup();
-    const renderedWcLinks = map.querySourceFeatures("watercourseLinks");
-    const renderedHNs = map.querySourceFeatures("hydroNodes");
+  const upstreamWcLinks = await getUpstream(id);
+  closePopup();
 
-    const allWcLinks = mergeFeatures(upstreamWatercourseLinks, renderedWcLinks);
+  const renderedWcLinks = map.querySourceFeatures("watercourseLinks");
+  const renderedHNs = map.querySourceFeatures("hydroNodes");
 
-    map.getSource("watercourseLinks").setData(allWcLinks);
-    map.getSource("hydroNodes").setData({
-      type: "FeatureCollection",
-      features: [...renderedHNs],
-    });
-    map.getSource("upstreamWatercourseLinks").setData(upstreamWatercourseLinks);
+  const allWcLinks = mergeFeatures(upstreamWcLinks, renderedWcLinks);
 
-    fitMapToFeatures(map, allWcLinks.features);
-    await map.once("idle");
-
-    const mapBounds = getMapBoundingBox(map);
-    const box = bboxPolygon(mapBounds);
-    map.getSource("bbox").setData(box);
+  map.getSource("watercourseLinks").setData(allWcLinks);
+  map.getSource("hydroNodes").setData({
+    type: "FeatureCollection",
+    features: [...renderedHNs],
   });
+  map.getSource("upstreamWatercourseLinks").setData(upstreamWcLinks);
+
+  fitMapToFeatures(map, allWcLinks.features);
+  await map.once("idle");
+
+  const mapBounds = getMapBoundingBox(map);
+  const box = bboxPolygon(mapBounds);
+  map.getSource("bbox").setData(box);
 };
 
 const getDownstream = async (id) => {

--- a/src/utils/popups.js
+++ b/src/utils/popups.js
@@ -6,7 +6,9 @@ import {
   saveWatercourseLinkSiteAssociation,
   getURL,
   waterNetworkAPIBase,
+  mergeFeatures,
 } from "../utils/water-network-data";
+import { bboxPolygon, getMapBoundingBox } from "./map";
 
 const getLastURLSegment = (url) => {
   return url.split("/").pop();
@@ -61,10 +63,33 @@ const getUpstream = async (id) => {
 };
 // TODO: catch 404s
 const highlightUpstreamWatercourseLinks = async (id, map) => {
-  await getUpstream(id).then((upstreamWatercourseLinks) => {
+  await getUpstream(id).then(async (upstreamWatercourseLinks) => {
     closePopup();
+    const renderedWcLinks = map.querySourceFeatures("watercourseLinks");
+    const allWcLinks = mergeFeatures(upstreamWatercourseLinks, renderedWcLinks);
+
+    map.getSource("watercourseLinks").setData(allWcLinks);
     map.getSource("upstreamWatercourseLinks").setData(upstreamWatercourseLinks);
+
+    fitMapToFeatures(map, allWcLinks.features);
+    await map.once("idle");
+
+    const mapBounds = getMapBoundingBox(map);
+    const box = bboxPolygon(mapBounds);
+    map.getSource("bbox").setData(box);
   });
+};
+
+const fitMapToFeatures = (map, features) => {
+  var bounds = new mapboxgl.LngLatBounds();
+
+  features.forEach((feature) => {
+    feature.geometry.coordinates.forEach((coords) => {
+      bounds.extend(coords);
+    });
+  });
+
+  map.fitBounds(bounds, { padding: 20 });
 };
 
 const getDownstream = async (id) => {

--- a/src/utils/popups.js
+++ b/src/utils/popups.js
@@ -61,9 +61,9 @@ const getUpstream = async (id) => {
 };
 // TODO: catch 404s
 const highlightUpstreamWatercourseLinks = async (id, map) => {
-  await getUpstream(id).then((watercourseLinks) => {
+  await getUpstream(id).then((upstreamWatercourseLinks) => {
     closePopup();
-    map.getSource("highlightWatercourseLink").setData(watercourseLinks);
+    map.getSource("upstreamWatercourseLinks").setData(upstreamWatercourseLinks);
   });
 };
 
@@ -73,9 +73,11 @@ const getDownstream = async (id) => {
 };
 
 const highlightDownstreamWatercourseLinks = async (id, map) => {
-  await getDownstream(id).then((watercourseLinks) => {
+  await getDownstream(id).then((downstreamWatercourseLinks) => {
     closePopup();
-    map.getSource("highlightWatercourseLink").setData(watercourseLinks);
+    map
+      .getSource("downstreamWatercourseLinks")
+      .setData(downstreamWatercourseLinks);
   });
 };
 

--- a/src/utils/popups.js
+++ b/src/utils/popups.js
@@ -57,6 +57,26 @@ const wcLinkPopupHTML = (title, displayProps) => {
           ${downstreamWCLinks}`;
 };
 
+const fitMapToFeatures = (map, features) => {
+  var bounds = new mapboxgl.LngLatBounds();
+
+  features.forEach((feature) => {
+    if (feature.geometry.type === "LineString") {
+      feature.geometry.coordinates.forEach((coords) => {
+        bounds.extend(coords);
+      });
+    } else if (feature.geometry.type === "MultiLineString") {
+      feature.geometry.coordinates.forEach((line) => {
+        line.forEach((coords) => {
+          bounds.extend(coords);
+        });
+      });
+    }
+  });
+
+  map.fitBounds(bounds, { padding: 20 });
+};
+
 const getUpstream = async (id) => {
   const url = `${waterNetworkAPIBase}/collections/WatercourseLink/items/${id}/upstream`;
   return await getURL(url);
@@ -78,18 +98,6 @@ const highlightUpstreamWatercourseLinks = async (id, map) => {
     const box = bboxPolygon(mapBounds);
     map.getSource("bbox").setData(box);
   });
-};
-
-const fitMapToFeatures = (map, features) => {
-  var bounds = new mapboxgl.LngLatBounds();
-
-  features.forEach((feature) => {
-    feature.geometry.coordinates.forEach((coords) => {
-      bounds.extend(coords);
-    });
-  });
-
-  map.fitBounds(bounds, { padding: 20 });
 };
 
 const getDownstream = async (id) => {

--- a/src/utils/popups.js
+++ b/src/utils/popups.js
@@ -86,9 +86,15 @@ const highlightUpstreamWatercourseLinks = async (id, map) => {
   await getUpstream(id).then(async (upstreamWatercourseLinks) => {
     closePopup();
     const renderedWcLinks = map.querySourceFeatures("watercourseLinks");
+    const renderedHNs = map.querySourceFeatures("hydroNodes");
+
     const allWcLinks = mergeFeatures(upstreamWatercourseLinks, renderedWcLinks);
 
     map.getSource("watercourseLinks").setData(allWcLinks);
+    map.getSource("hydroNodes").setData({
+      type: "FeatureCollection",
+      features: [...renderedHNs],
+    });
     map.getSource("upstreamWatercourseLinks").setData(upstreamWatercourseLinks);
 
     fitMapToFeatures(map, allWcLinks.features);
@@ -109,12 +115,17 @@ const highlightDownstreamWatercourseLinks = async (id, map) => {
   await getDownstream(id).then(async (downstreamWatercourseLinks) => {
     closePopup();
     const renderedWcLinks = map.querySourceFeatures("watercourseLinks");
+    const renderedHNs = map.querySourceFeatures("hydroNodes");
     const allWcLinks = mergeFeatures(
       downstreamWatercourseLinks,
       renderedWcLinks
     );
 
     map.getSource("watercourseLinks").setData(allWcLinks);
+    map.getSource("hydroNodes").setData({
+      type: "FeatureCollection",
+      features: [...renderedHNs],
+    });
     map
       .getSource("downstreamWatercourseLinks")
       .setData(downstreamWatercourseLinks);

--- a/src/utils/popups.js
+++ b/src/utils/popups.js
@@ -106,11 +106,25 @@ const getDownstream = async (id) => {
 };
 
 const highlightDownstreamWatercourseLinks = async (id, map) => {
-  await getDownstream(id).then((downstreamWatercourseLinks) => {
+  await getDownstream(id).then(async (downstreamWatercourseLinks) => {
     closePopup();
+    const renderedWcLinks = map.querySourceFeatures("watercourseLinks");
+    const allWcLinks = mergeFeatures(
+      downstreamWatercourseLinks,
+      renderedWcLinks
+    );
+
+    map.getSource("watercourseLinks").setData(allWcLinks);
     map
       .getSource("downstreamWatercourseLinks")
       .setData(downstreamWatercourseLinks);
+
+    fitMapToFeatures(map, allWcLinks.features);
+    await map.once("idle");
+
+    const mapBounds = getMapBoundingBox(map);
+    const box = bboxPolygon(mapBounds);
+    map.getSource("bbox").setData(box);
   });
 };
 

--- a/src/utils/water-network-data.js
+++ b/src/utils/water-network-data.js
@@ -78,15 +78,21 @@ export const displayWaterNetworkFeaturesInMapViewport = async (map) => {
   const box = bboxPolygon(mapBounds);
   map.getSource("bbox").setData(box);
 
-  await getFeaturesInBoundingBox("HydroNode", mapBounds).then((hydroNodes) => {
-    map.getSource("hydroNodes").setData(hydroNodes);
-  });
+  await getFeaturesInBoundingBox("HydroNode", mapBounds)
+    .then((hydroNodes) => {
+      map.getSource("hydroNodes").setData(hydroNodes);
+    })
+    .catch((error) => {
+      console.error(error);
+    });
 
-  await getFeaturesInBoundingBox("WatercourseLink", mapBounds).then(
-    (watercourseLinks) => {
+  await getFeaturesInBoundingBox("WatercourseLink", mapBounds)
+    .then((watercourseLinks) => {
       map.getSource("watercourseLinks").setData(watercourseLinks);
-    }
-  );
+    })
+    .catch((error) => {
+      console.error(error);
+    });
 };
 
 export const getWatercourseLink = async (id) => {

--- a/src/utils/water-network-data.js
+++ b/src/utils/water-network-data.js
@@ -39,12 +39,12 @@ const getNextPageLink = (response) => {
   }
 };
 
-const mergeFeatures = (response, nextPageResponse) => {
-  const allFeatures = response.features.concat(...nextPageResponse.features);
+export const mergeFeatures = (response, otherFeatures) => {
+  const allFeatures = otherFeatures.concat(...response.features);
   return {
-    ...nextPageResponse,
+    ...response,
     features: allFeatures,
-    numberReturned: response.numberReturned + nextPageResponse.numberReturned,
+    numberReturned: otherFeatures.length + response.numberReturned,
   };
 };
 
@@ -53,7 +53,7 @@ const getBBoxPages = async (response) => {
 
   if (nextPageLink) {
     const nextPageResponse = await getURL(nextPageLink);
-    const nextResponse = mergeFeatures(response, nextPageResponse);
+    const nextResponse = mergeFeatures(nextPageResponse, response.features);
     return getBBoxPages(nextResponse);
   } else {
     return response;


### PR DESCRIPTION
Addressing feedback to improve the _show upstream/downstream_ feature.

## When clicking show downstream/upstream is it possible to zoom to show?
Yes! Now after you click to show downstream/upstream, the map will zoom out to show all the upstream/downstream watercourse links and draw a new bbox around the new viewport!

### Limitations
When you click _show downstream/upstream_, any hydro nodes or watercourse links outside the viewport will be removed
  - so if you zoom in before you click to show downstream/upstream wclinks, you'll lose some of the features that were initially rendered e.g:
  
![image](https://user-images.githubusercontent.com/32230328/197263436-8d140153-d080-490e-ab76-533fe1a2daef.png)

![image](https://user-images.githubusercontent.com/32230328/197263587-d3909254-0aeb-4d7b-a3c6-de1813f2c219.png)

![image](https://user-images.githubusercontent.com/32230328/197264429-dd00ef1b-6e5f-4e55-b312-cad094276f23.png)

### To do
Add hydro nodes along the upstream/downstream watercourse links
- Right now I think the only way to do this is to iterate through the watercourse links to grab their startNode/endNode and then [fetch each hydro node](https://defra-water-network-prod.publishmydata.com/water-network/docs/hydronode-details)
- We have a "fetch features by id" query, which we could use for its own endpoint but I don't know if adding another endpoint to fulfil the needs of the demo app is good 🤔 

Add monitoring sites along the upstream/downstream watercourse links
- Not entirely sure how to do this to be honest 
- Could look up sites with user associated watercourse links, but that might miss out a lot of sites
- The other option might be to show fewer upstream/downstream watercourse links (right now we're showing 50) and then just getting all features in the zoomed out bbox?
   - Would mean that you wouldn't have hydro nodes/ watercourse links disappearing as mentioned in the limitation above

## Can the red line be styled more (eg chevrons to show direction)?
Yes! Thanks to Ben, we now have chevrons indicating the direction of the watercourse links relative to the inital one 😍:

![image](https://user-images.githubusercontent.com/32230328/197268249-4b306a78-a505-4f0f-a19b-419043bff9c7.png)
(near the top left you can see there's a missing watercourse link - since it was outside the viewport)

Upstream in pink, downstream in blue - happy to change colours of course!