### PR TITLE
Likelihood of correct site watercourse link association

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -39,7 +39,7 @@ td {
   overflow-wrap: anywhere;
 }
 
-.mapboxgl-popup.mapboxgl-popup-anchor-bottom {
+.mapboxgl-popup {
   max-width: 320px !important;
 }
 

--- a/src/utils/html-strings.js
+++ b/src/utils/html-strings.js
@@ -1,0 +1,36 @@
+export const tableHeader = (val) => {
+  return `<th style="vertical-align: top">${val}</th>`;
+};
+
+export const tableCell = (val) => {
+  return `<td style="vertical-align: top">${val}</td>`;
+};
+
+export const toTableCells = (displayProps) => {
+  return Object.entries(displayProps)
+    .map(([key, value]) => {
+      return `<tr>
+${tableHeader(key)}
+${tableCell(value)}
+     </tr>`;
+    })
+    .join("");
+};
+
+export const tableHTML = (title, cellHTML) => {
+  return `<table style="width: 100%">
+       <caption style="font-weight: bold; caption-side: top">${title}</caption>
+        ${cellHTML}
+     </table>`;
+};
+
+export const button = (extraAttributes, text) => {
+  return `<button class="govuk-button btn-sm mt-3"
+                                   style="font-size:0.9rem; margin:0"
+                                   ${extraAttributes}
+                           >${text}</button>`;
+};
+
+export const link = (url, text) => {
+  return `<a target="_blank" href=${url}>${text}</a>`;
+};

--- a/src/utils/html-strings.js
+++ b/src/utils/html-strings.js
@@ -24,7 +24,7 @@ export const tableHTML = (title, cellHTML) => {
                             padding-bottom: 5px;"`;
   return `
   <div ${scrollCss}>
-    <table>
+    <table style="width: 100%">
       <caption style="font-weight: bold; caption-side: top">${title}</caption>
         ${cellHTML}
     </table>

--- a/src/utils/html-strings.js
+++ b/src/utils/html-strings.js
@@ -18,10 +18,17 @@ ${tableCell(value)}
 };
 
 export const tableHTML = (title, cellHTML) => {
-  return `<table style="width: 100%">
-       <caption style="font-weight: bold; caption-side: top">${title}</caption>
+  const scrollCss = `style="max-height: 20rem;
+                            overflow: auto;
+                            scrollbar-width: thin;
+                            padding-bottom: 5px;"`;
+  return `
+  <div ${scrollCss}>
+    <table>
+      <caption style="font-weight: bold; caption-side: top">${title}</caption>
         ${cellHTML}
-     </table>`;
+    </table>
+  </div>`;
 };
 
 export const button = (extraAttributes, text) => {

--- a/src/utils/map.js
+++ b/src/utils/map.js
@@ -79,7 +79,7 @@ export const setupEmptyOverlays = (map) => {
       "line-cap": "round",
     },
     paint: {
-      "line-color": "red",
+      "line-color": "#06a516",
       "line-width": 8,
     },
   });

--- a/src/utils/nearest-wc-link-to-site.js
+++ b/src/utils/nearest-wc-link-to-site.js
@@ -74,7 +74,8 @@ export const highlightNearestWatercourseLink = async (site, map) => {
     unhighlightWatercourseLink(map);
     return null;
   } else if (userAssociatedWCLink) {
-    wcLink = userAssociatedWCLink;
+    wcLink = { ...userAssociatedWCLink, certainty: "certain" };
+    allLinks = { wcLinks: [userAssociatedWCLink] };
     userSelected = true;
   } else {
     const coords = site.geometry.coordinates;

--- a/src/utils/nearest-wc-link-to-site.js
+++ b/src/utils/nearest-wc-link-to-site.js
@@ -11,9 +11,22 @@ const getNearestWCLinkToPoint = async (coords) => {
     waterNetworkAPIBase +
     "/collections/WatercourseLink/items" +
     "?point=" +
-    coords.join(",");
+    coords.join(",") +
+    "&multiple=true";
 
-  return await getURL(url);
+  const wcLinkResponse = await getURL(url);
+  const wcLinks = wcLinkResponse.features;
+  const nearest = wcLinks[0];
+  const distanceBetweenNearestTwo =
+    wcLinks[1].distanceFromSearchPoint - nearest.distanceFromSearchPoint;
+
+  if (distanceBetweenNearestTwo > 20) {
+    return { ...nearest, certainty: "certain" };
+  } else if (distanceBetweenNearestTwo > 5) {
+    return { ...nearest, certainty: "probable" };
+  } else {
+    return { ...nearest, certainty: "ambiguous" };
+  }
 };
 
 const getUserAssociatedWCLink = async (siteURI) => {
@@ -29,6 +42,20 @@ const getUserAssociatedWCLink = async (siteURI) => {
   } else {
     return await result.json();
   }
+};
+
+const setHighlightedWcLink = (map, wcLink) => {
+  const certaintyToColour = {
+    certain: "#06a516",
+    probable: "#ffec44",
+    ambiguous: "#9949cc",
+  };
+  map.setPaintProperty(
+    "highlightWatercourseLink",
+    "line-color",
+    certaintyToColour[wcLink.certainty]
+  );
+  map.getSource("highlightWatercourseLink").setData(wcLink);
 };
 
 export const highlightNearestWatercourseLink = async (site, map) => {
@@ -47,5 +74,5 @@ export const highlightNearestWatercourseLink = async (site, map) => {
     wcLink = await getNearestWCLinkToPoint(coords);
   }
 
-  map.getSource("highlightWatercourseLink").setData(wcLink);
+  setHighlightedWcLink(map, wcLink);
 };

--- a/src/utils/nearest-wc-link-to-site.js
+++ b/src/utils/nearest-wc-link-to-site.js
@@ -17,15 +17,19 @@ const getNearestWCLinkToPoint = async (coords) => {
   const wcLinkResponse = await getURL(url);
   const wcLinks = wcLinkResponse.features;
   const nearest = wcLinks[0];
-  const distanceBetweenNearestTwo =
-    wcLinks[1].distanceFromSearchPoint - nearest.distanceFromSearchPoint;
+  const nextNearest = wcLinks[1];
+  let distanceBetweenNearestTwo = Infinity;
+  if (nearest && nextNearest) {
+    distanceBetweenNearestTwo =
+      wcLinks[1].distanceFromSearchPoint - nearest.distanceFromSearchPoint;
+  }
 
   if (distanceBetweenNearestTwo > 20) {
-    return { ...nearest, certainty: "certain" };
+    return { wcLinks: wcLinks, certainty: "certain" };
   } else if (distanceBetweenNearestTwo > 5) {
-    return { ...nearest, certainty: "probable" };
+    return { wcLinks: wcLinks, certainty: "probable" };
   } else {
-    return { ...nearest, certainty: "ambiguous" };
+    return { wcLinks: wcLinks, certainty: "ambiguous" };
   }
 };
 
@@ -53,7 +57,7 @@ const setHighlightedWcLink = (map, wcLink) => {
   map.setPaintProperty(
     "highlightWatercourseLink",
     "line-color",
-    certaintyToColour[wcLink.certainty]
+    certaintyToColour[wcLink.certainty] || "#06a516"
   );
   map.getSource("highlightWatercourseLink").setData(wcLink);
 };
@@ -62,18 +66,22 @@ export const highlightNearestWatercourseLink = async (site, map) => {
   const siteURI = site.properties.uri;
   const userAssociatedWCLink = await getUserAssociatedWCLink(siteURI);
 
+  let allLinks = null;
   let wcLink = null;
+  let userSelected = false;
 
   if (userAssociatedWCLink?.status === "No watercourse link") {
     unhighlightWatercourseLink(map);
     return null;
   } else if (userAssociatedWCLink) {
     wcLink = userAssociatedWCLink;
+    userSelected = true;
   } else {
     const coords = site.geometry.coordinates;
-    wcLink = await getNearestWCLinkToPoint(coords);
+    allLinks = await getNearestWCLinkToPoint(coords);
+    wcLink = { ...allLinks.wcLinks[0], certainty: allLinks.certainty };
   }
 
   setHighlightedWcLink(map, wcLink);
-  return wcLink;
+  return { wcLinks: allLinks.wcLinks, userSelected: userSelected };
 };

--- a/src/utils/nearest-wc-link-to-site.js
+++ b/src/utils/nearest-wc-link-to-site.js
@@ -38,7 +38,7 @@ const getUserAssociatedWCLink = async (siteURI) => {
   const result = await fetch(url, { method: "GET", headers: headers });
 
   if (result.status === 404) {
-    return;
+    return null;
   } else {
     return await result.json();
   }
@@ -66,7 +66,7 @@ export const highlightNearestWatercourseLink = async (site, map) => {
 
   if (userAssociatedWCLink?.status === "No watercourse link") {
     unhighlightWatercourseLink(map);
-    return;
+    return null;
   } else if (userAssociatedWCLink) {
     wcLink = userAssociatedWCLink;
   } else {
@@ -75,4 +75,5 @@ export const highlightNearestWatercourseLink = async (site, map) => {
   }
 
   setHighlightedWcLink(map, wcLink);
+  return wcLink;
 };

--- a/src/utils/popups.js
+++ b/src/utils/popups.js
@@ -23,20 +23,6 @@ const getLastURLSegment = (url) => {
 };
 
 const basicPopupTableHTML = (title, displayProps) => {
-  let scrollCss = "";
-  if (Object.keys(displayProps).length > 5) {
-    scrollCss = `style="height: 20rem; overflow: auto; scrollbar-width: thin; padding-bottom: 5px;"`;
-  }
-
-  return `
-  <div ${scrollCss}>
-    <table>
-      <caption style="font-weight: bold; caption-side: top">${title}</caption>
-        ${toTableCells(displayProps)}
-    </table>
-  </div>`;
-
-  TODO: move the above scroll improvements into tableHTML
   return tableHTML(title, toTableCells(displayProps));
 };
 
@@ -159,9 +145,9 @@ const enableAssociateWatercourseLinkMode = (siteURI, setMapContext) => {
 const nearbyWCLinkTableHTML = (nearestLinksResponse) => {
   if (nearestLinksResponse) {
     const props = {};
-    nearestLinksResponse.wcLinks.map((link) => {
+    for (const link of nearestLinksResponse.wcLinks) {
       props[link.properties.id] = `${link.distanceFromSearchPoint}m`;
-    });
+    }
 
     const heading = `<tr>${tableHeader("Watercourse Link ID")}${tableHeader(
       "Distance"

--- a/src/utils/popups.js
+++ b/src/utils/popups.js
@@ -144,24 +144,30 @@ const enableAssociateWatercourseLinkMode = (siteURI, setMapContext) => {
 
 const nearbyWCLinkTableHTML = (nearestLinksResponse) => {
   if (nearestLinksResponse) {
-    const props = {};
-    for (const link of nearestLinksResponse.wcLinks) {
-      props[link.properties.id] = `${link.distanceFromSearchPoint}m`;
-    }
+    const { wcLinks, userSelected } = nearestLinksResponse;
 
-    const heading = `<tr>${tableHeader("Watercourse Link ID")}${tableHeader(
-      "Distance"
-    )}`;
-    const rows = Object.entries(props)
-      .map(([key, value]) => {
-        return ` <tr>
+    if (wcLinks && !userSelected) {
+      const props = {};
+      for (const link of wcLinks) {
+        props[link.properties.id] = `${link.distanceFromSearchPoint}m`;
+      }
+
+      const heading = `<tr>${tableHeader("Watercourse Link ID")}${tableHeader(
+        "Distance"
+      )}`;
+      const rows = Object.entries(props)
+        .map(([key, value]) => {
+          return ` <tr>
 ${tableCell(key)}
 ${tableCell(value)}
      </tr>`;
-      })
-      .join("");
+        })
+        .join("");
 
-    return tableHTML("Nearest Watercourse Links", [heading, rows].join(""));
+      return tableHTML("Nearest Watercourse Links", [heading, rows].join(""));
+    } else {
+      return "";
+    }
   } else {
     return "";
   }
@@ -233,6 +239,11 @@ const sitePropertiesToHTML = ({ properties, source, nearestLinksResponse }) => {
 
   if (properties.flow) {
     displayProps["Latest complete flow reading"] = properties.flow;
+  }
+
+  if (nearestLinksResponse?.userSelected) {
+    displayProps["Associated Watercourse Link"] =
+      nearestLinksResponse.wcLinks[0].properties.id;
   }
 
   return sitePopupHTML(


### PR DESCRIPTION
This PR adds info about the nearest watercourse links to a site to the popups and colours the watercourse links differently depending on how many are near a site. If the distance between the nearest 2 watercourse links is more than 20m, links are coloured green, which is meant to indicate that we are quite certain the link goes with that site. Yellow is for "pretty sure" (between 5-20m between nearest 2 watercourse links) and purple is for "ambiguous" (less than 5m).

"Denham" is a good area to search that has several sites of each type to see what this looks like, but this is the idea:

Site with 2 links that are almost equally far away:

<img width="442" alt="image" src="https://user-images.githubusercontent.com/11531673/203820603-b667cf5e-6c60-4483-aed8-2a0b54ab5db5.png">

 (in the popup you can there <5m different between their distances):
<img width="327" alt="image" src="https://user-images.githubusercontent.com/11531673/203820783-002bd15c-c6be-41e6-b1c3-90b2c7a6fb56.png">

